### PR TITLE
riot+compiler wasn't needed. Just riot

### DIFF
--- a/gulp_tasks/gulp.paths.js
+++ b/gulp_tasks/gulp.paths.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     libs: {
         script: [
-            GLOBAL_PATHS.node+"riot/riot+compiler.min.js",
+            GLOBAL_PATHS.node+"riot/riot.min.js",
             GLOBAL_PATHS.node+"riotgear/dist/rg.min.js"
         ]
     },


### PR DESCRIPTION
This solution is only less than 30k if you don't use the riot+compiler.min.js and instead use riot.min.js.  Since you're compiling the riot tags with gulp you don't need to include the compiler as part of the final build.